### PR TITLE
Show posts on explore page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "18.2.0",
         "react-native": "0.72.6",
         "react-native-paper": "^5.11.1",
+        "react-native-render-html": "^6.3.4",
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0",
         "react-native-web": "~0.19.6",
@@ -4019,10 +4020,86 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsamr/counter-style": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jsamr/counter-style/-/counter-style-2.0.2.tgz",
+      "integrity": "sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ=="
+    },
+    "node_modules/@jsamr/react-native-li": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@jsamr/react-native-li/-/react-native-li-2.3.1.tgz",
+      "integrity": "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==",
+      "peerDependencies": {
+        "@jsamr/counter-style": "^1.0.0 || ^2.0.0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@native-html/css-processor": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@native-html/css-processor/-/css-processor-1.11.0.tgz",
+      "integrity": "sha512-NnhBEbJX5M2gBGltPKOetiLlKhNf3OHdRafc8//e2ZQxXN8JaSW/Hy8cm94pnIckQxwaMKxrtaNT3x4ZcffoNQ==",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "csstype": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*"
+      }
+    },
+    "node_modules/@native-html/transient-render-engine": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@native-html/transient-render-engine/-/transient-render-engine-11.2.3.tgz",
+      "integrity": "sha512-zXwgA3gPUEmFs3I3syfnvDvS6WiUHXEE6jY09OBzK+trq7wkweOSFWIoyXiGkbXrozGYG0KY90YgPyr8Tg8Uyg==",
+      "dependencies": {
+        "@native-html/css-processor": "1.11.0",
+        "@types/ramda": "^0.27.44",
+        "csstype": "^3.0.9",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "htmlparser2": "^7.1.2",
+        "ramda": "^0.27.2"
+      },
+      "peerDependencies": {
+        "@types/react-native": "*",
+        "react-native": "^*"
+      }
+    },
+    "node_modules/@native-html/transient-render-engine/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@native-html/transient-render-engine/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6581,6 +6658,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
       "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
+    "node_modules/@types/ramda": {
+      "version": "0.27.66",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.66.tgz",
+      "integrity": "sha512-i2YW+E2U6NfMt3dp0RxNcejox+bxJUNDjB7BpYuRuoHIzv5juPHkJkNgcUOu+YSQEmaWu8cnAo/8r63C0NnuVA==",
+      "dependencies": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -6594,6 +6679,16 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-native": {
+      "version": "0.72.6",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.6.tgz",
+      "integrity": "sha512-5Tan0ejOjbYyrnRreRZ7ftcWbehQELoHevJQliAu0Rhqrsnall8dyodf/434jdDJuQEzLisBMg7ZkQNnghUXIw==",
+      "peer": true,
+      "dependencies": {
+        "@react-native/virtualized-lists": "^0.72.4",
+        "@types/react": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -6651,6 +6746,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw=="
+    },
+    "node_modules/@types/urijs": {
+      "version": "1.19.23",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.23.tgz",
+      "integrity": "sha512-3Zbk6RzmIpvKTNEHO2RcPOGHM++BQEITMqBRR1Ju32WbruhV/pygYgxiP3xA0b1B88zjzs0Izzjxsbj768+IjA=="
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -8328,6 +8428,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -8369,6 +8477,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/charenc": {
@@ -8989,6 +9115,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
@@ -9170,6 +9304,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -17313,6 +17457,11 @@
         }
       ]
     },
+    "node_modules/ramda": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -17519,6 +17668,26 @@
       "dependencies": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/react-native-render-html": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/react-native-render-html/-/react-native-render-html-6.3.4.tgz",
+      "integrity": "sha512-H2jSMzZjidE+Wo3qCWPUMU1nm98Vs2SGCvQCz/i6xf0P3Y9uVtG/b0sDbG/cYFir2mSYBYCIlS1Dv0WC1LjYig==",
+      "dependencies": {
+        "@jsamr/counter-style": "^2.0.1",
+        "@jsamr/react-native-li": "^2.3.0",
+        "@native-html/transient-render-engine": "11.2.3",
+        "@types/ramda": "^0.27.40",
+        "@types/urijs": "^1.19.15",
+        "prop-types": "^15.5.7",
+        "ramda": "^0.27.2",
+        "stringify-entities": "^3.1.0",
+        "urijs": "^1.19.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -19027,6 +19196,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
+      "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
+      "dependencies": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -19620,6 +19803,11 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -19973,6 +20161,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
     },
     "node_modules/url-join": {
       "version": "4.0.0",
@@ -23741,10 +23934,63 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@jsamr/counter-style": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jsamr/counter-style/-/counter-style-2.0.2.tgz",
+      "integrity": "sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ=="
+    },
+    "@jsamr/react-native-li": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@jsamr/react-native-li/-/react-native-li-2.3.1.tgz",
+      "integrity": "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==",
+      "requires": {}
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "@native-html/css-processor": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@native-html/css-processor/-/css-processor-1.11.0.tgz",
+      "integrity": "sha512-NnhBEbJX5M2gBGltPKOetiLlKhNf3OHdRafc8//e2ZQxXN8JaSW/Hy8cm94pnIckQxwaMKxrtaNT3x4ZcffoNQ==",
+      "requires": {
+        "css-to-react-native": "^3.0.0",
+        "csstype": "^3.0.8"
+      }
+    },
+    "@native-html/transient-render-engine": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@native-html/transient-render-engine/-/transient-render-engine-11.2.3.tgz",
+      "integrity": "sha512-zXwgA3gPUEmFs3I3syfnvDvS6WiUHXEE6jY09OBzK+trq7wkweOSFWIoyXiGkbXrozGYG0KY90YgPyr8Tg8Uyg==",
+      "requires": {
+        "@native-html/css-processor": "1.11.0",
+        "@types/ramda": "^0.27.44",
+        "csstype": "^3.0.9",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "htmlparser2": "^7.1.2",
+        "ramda": "^0.27.2"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -25611,6 +25857,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
       "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
+    "@types/ramda": {
+      "version": "0.27.66",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.66.tgz",
+      "integrity": "sha512-i2YW+E2U6NfMt3dp0RxNcejox+bxJUNDjB7BpYuRuoHIzv5juPHkJkNgcUOu+YSQEmaWu8cnAo/8r63C0NnuVA==",
+      "requires": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
     "@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -25624,6 +25878,16 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.72.6",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.72.6.tgz",
+      "integrity": "sha512-5Tan0ejOjbYyrnRreRZ7ftcWbehQELoHevJQliAu0Rhqrsnall8dyodf/434jdDJuQEzLisBMg7ZkQNnghUXIw==",
+      "peer": true,
+      "requires": {
+        "@react-native/virtualized-lists": "^0.72.4",
+        "@types/react": "*"
       }
     },
     "@types/retry": {
@@ -25681,6 +25945,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw=="
+    },
+    "@types/urijs": {
+      "version": "1.19.23",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.23.tgz",
+      "integrity": "sha512-3Zbk6RzmIpvKTNEHO2RcPOGHM++BQEITMqBRR1Ju32WbruhV/pygYgxiP3xA0b1B88zjzs0Izzjxsbj768+IjA=="
     },
     "@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -26951,6 +27220,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
     },
+    "camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -26976,6 +27250,16 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "charenc": {
       "version": "0.0.2",
@@ -27432,6 +27716,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+    },
     "css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
@@ -27549,6 +27838,16 @@
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
+      }
+    },
+    "css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-tree": {
@@ -33433,6 +33732,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
+    "ramda": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -33618,6 +33922,22 @@
             "color-string": "^1.6.0"
           }
         }
+      }
+    },
+    "react-native-render-html": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/react-native-render-html/-/react-native-render-html-6.3.4.tgz",
+      "integrity": "sha512-H2jSMzZjidE+Wo3qCWPUMU1nm98Vs2SGCvQCz/i6xf0P3Y9uVtG/b0sDbG/cYFir2mSYBYCIlS1Dv0WC1LjYig==",
+      "requires": {
+        "@jsamr/counter-style": "^2.0.1",
+        "@jsamr/react-native-li": "^2.3.0",
+        "@native-html/transient-render-engine": "11.2.3",
+        "@types/ramda": "^0.27.40",
+        "@types/urijs": "^1.19.15",
+        "prop-types": "^15.5.7",
+        "ramda": "^0.27.2",
+        "stringify-entities": "^3.1.0",
+        "urijs": "^1.19.6"
       }
     },
     "react-native-safe-area-context": {
@@ -34764,6 +35084,16 @@
         "es-abstract": "^1.22.1"
       }
     },
+    "stringify-entities": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
+      "integrity": "sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==",
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -35177,6 +35507,11 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -35417,6 +35752,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
     },
     "url-join": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.6",
     "react-native-paper": "^5.11.1",
+    "react-native-render-html": "^6.3.4",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-web": "~0.19.6",

--- a/src/components/HtmlRenderer.tsx
+++ b/src/components/HtmlRenderer.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useWindowDimensions } from "react-native";
+import HTML, { MixedStyleRecord } from "react-native-render-html";
+
+interface HTMLRendererProps {
+  htmlContent: string;
+  tagsStyles: MixedStyleRecord;
+  defaultTextProps: any;
+}
+
+const HTMLRenderer: React.FC<HTMLRendererProps> = ({
+  htmlContent,
+  tagsStyles,
+  defaultTextProps,
+}) => {
+  const { width } = useWindowDimensions();
+
+  return (
+    <HTML
+      tagsStyles={tagsStyles}
+      contentWidth={width}
+      source={{ html: htmlContent }}
+      defaultTextProps={defaultTextProps}
+    />
+  );
+};
+
+export default HTMLRenderer;

--- a/src/components/WordPressPost.tsx
+++ b/src/components/WordPressPost.tsx
@@ -1,0 +1,28 @@
+import { WordPressPostProps } from "@components/types";
+import { htmlTagStyles, postStyles } from "@utils/styles";
+import React from "react";
+import { View, Text, Image } from "react-native";
+
+import HTMLRenderer from "./HtmlRenderer";
+const WordPressPost: React.FC<WordPressPostProps> = ({
+  title,
+  imageUrl,
+  excerpt,
+}) => {
+  const defaultTextProps = {
+    numberOfLines: 4,
+  };
+  return (
+    <View style={postStyles.container}>
+      <Image source={{ uri: imageUrl }} style={postStyles.image} />
+      <Text style={postStyles.title}>{title}</Text>
+      <HTMLRenderer
+        tagsStyles={htmlTagStyles.tagStyles}
+        htmlContent={excerpt}
+        defaultTextProps={defaultTextProps}
+      />
+    </View>
+  );
+};
+
+export default WordPressPost;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,5 @@
+export interface WordPressPostProps {
+  title: string;
+  imageUrl: string;
+  excerpt: string;
+}

--- a/src/screens/ExplorePage.tsx
+++ b/src/screens/ExplorePage.tsx
@@ -1,17 +1,32 @@
+import WordPressPost from "@components/WordPressPost";
 import { usePosts } from "@storage/hooks/usePosts"; // Adjust the import path based on your project structure
+import { decodeText } from "@utils/helper";
 import React, { useEffect } from "react";
-import { View, Text } from "react-native";
+import { View, ScrollView, RefreshControl } from "react-native";
 
 const ExplorePage: React.FC = () => {
-  const { posts, loading, error } = usePosts();
-  console.log(posts);
+  const { posts, loading, error, refetchPosts } = usePosts();
+
   useEffect(() => {
     // Do something with posts, loading, error
   }, [posts, loading, error]);
 
   return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-      <Text>Home!</Text>
+      <ScrollView
+        refreshControl={
+          <RefreshControl refreshing={loading} onRefresh={refetchPosts} />
+        }
+      >
+        {posts.map((item, index) => (
+          <WordPressPost
+            imageUrl={item.jetpack_featured_media_url}
+            title={decodeText(item.title.rendered)}
+            excerpt={decodeText(item.excerpt.rendered)}
+            key={index}
+          />
+        ))}
+      </ScrollView>
     </View>
   );
 };

--- a/src/services/api/wordpressApi.ts
+++ b/src/services/api/wordpressApi.ts
@@ -8,7 +8,7 @@ const api = axios.create({
 const handleRequest = async <T>(request: Promise<AxiosResponse<T>>) => {
   try {
     const response = await request;
-    return response.data;
+    return Array.isArray(response.data) ? response.data : [response.data];
   } catch (error) {
     throw error;
   }

--- a/src/services/storage/actions/posts.ts
+++ b/src/services/storage/actions/posts.ts
@@ -33,8 +33,8 @@ export const fetchPosts =
     dispatch({ type: FETCH_POSTS_REQUEST });
 
     try {
-      const posts = await api.get("/posts");
-      dispatch({ type: FETCH_POSTS_SUCCESS, payload: [posts] });
+      const posts = await api.get("posts");
+      dispatch({ type: FETCH_POSTS_SUCCESS, payload: posts });
     } catch (error: any) {
       dispatch({ type: FETCH_POSTS_FAILURE, payload: error.message });
     }

--- a/src/services/storage/hooks/types.ts
+++ b/src/services/storage/hooks/types.ts
@@ -1,0 +1,20 @@
+export interface PostType {
+  id: number;
+  title: {
+    rendered: string;
+  };
+  jetpack_featured_media_url: string; // Replace with the actual field in your WordPress setup
+  excerpt: {
+    rendered: string;
+  };
+}
+
+export interface PostsType {
+  data: PostType[];
+}
+
+export interface PostsState {
+  posts: PostsType[]; // Update the type of posts as needed
+  loading: boolean;
+  error: string | null;
+}

--- a/src/services/storage/reducers/index.ts
+++ b/src/services/storage/reducers/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers, Reducer } from "redux";
 
-import postsReducer, { PostsState } from "./posts";
+import postsReducer from "./posts";
+import { PostsState } from "./types";
 
 // Define the type for the combined state
 export interface RootState {

--- a/src/services/storage/reducers/posts.ts
+++ b/src/services/storage/reducers/posts.ts
@@ -1,15 +1,9 @@
+import { PostsState } from "./types";
 import {
   FETCH_POSTS_REQUEST,
   FETCH_POSTS_SUCCESS,
   FETCH_POSTS_FAILURE,
 } from "../actions/actionTypes";
-
-// State type
-export interface PostsState {
-  posts: any[]; // Update the type of posts as needed
-  loading: boolean;
-  error: string | null;
-}
 
 // Action type
 export type PostsAction =

--- a/src/services/storage/reducers/types.ts
+++ b/src/services/storage/reducers/types.ts
@@ -1,0 +1,20 @@
+export interface PostType {
+  id: number;
+  title: {
+    rendered: string;
+  };
+  jetpack_featured_media_url: string; // Replace with the actual field in your WordPress setup
+  excerpt: {
+    rendered: string;
+  };
+}
+
+export interface PostsType {
+  data: PostType[];
+}
+
+export interface PostsState {
+  posts: PostType[]; // Update the type of posts as needed
+  loading: boolean;
+  error: string | null;
+}

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,0 +1,3 @@
+import { decode } from "html-entities";
+
+export const decodeText = (text: string) => decode(text);

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,0 +1,59 @@
+import { StyleSheet } from "react-native";
+import {
+  MixedStyleDeclaration,
+  MixedStyleRecord,
+} from "react-native-render-html";
+
+type WebViewStyle = {
+  tagStyles: MixedStyleRecord;
+  baseFontStyle: MixedStyleDeclaration;
+};
+
+export const globalStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: "#fff",
+  },
+  titleText: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 20,
+  },
+  paragraph: {
+    marginVertical: 8,
+    lineHeight: 20,
+  },
+});
+
+export const postStyles = StyleSheet.create({
+  container: {
+    marginBottom: 20,
+    marginHorizontal: 10,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: "#ddd",
+    borderRadius: 8,
+  },
+  image: {
+    width: "100%",
+    height: 200,
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "bold",
+    marginBottom: 5,
+  },
+  excerpt: {
+    fontSize: 16,
+  },
+});
+
+export const htmlTagStyles = {
+  tagStyles: {
+    p: {},
+  },
+  baseFontStyle: {},
+} satisfies WebViewStyle;


### PR DESCRIPTION
### Overview
This pull request introduces the ability to display WordPress posts on the explorer page. Users can now explore and read posts directly within the app.

### Changes Made
- Added a new `Explorer` page component to showcase WordPress posts.
- Integrated the `WordPressPost` component to display individual posts with images, titles, and short descriptions.
- Utilized the `HTMLRenderer` component for rendering HTML content within posts.
- Implemented data fetching from the WordPress API using the `getPosts` function from the `wpApi` service.

### Screenshots (if applicable)
![WhatsApp Image 2023-11-11 at 16 27 53](https://github.com/yakupafsin/WordpressMobileApp/assets/66640310/c5962a1a-5b2e-4093-b89b-f27f1de1935a)


### Additional Notes
- The `getPosts` function in the `wpApi` service handles fetching posts from the WordPress API.
- The `HTMLRenderer` component is used to render HTML content within post descriptions.
- Styles for components are organized in the `styles.ts` file.

### Testing
- [x] Verified that posts are displayed correctly on the explorer page.
- [x] Checked for proper rendering of HTML content in post descriptions.
- [x] Ensured the app remains responsive and functional.

### Checklist
- [x] The code follows the project's coding standards.
- [ ] Unit tests, if applicable, have been added or updated.
- [x] Documentation has been updated to reflect the changes introduced.

### Reviewer Guidance
Please pay special attention to the integration of the `Explorer` page, usage of the `WordPressPost` and `HTMLRenderer` components, and the handling of data fetching from the WordPress API.