### PR TITLE
Add Image Carousel to Explore Page for Popular Posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-native-render-html": "^6.3.4",
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0",
+        "react-native-swiper": "^1.6.0",
         "react-native-web": "~0.19.6",
         "react-redux": "^8.1.3",
         "redux": "^4.2.1",
@@ -17712,6 +17713,14 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-swiper": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-swiper/-/react-native-swiper-1.6.0.tgz",
+      "integrity": "sha512-OnkTTZi+9uZUgy0uz1I9oYDhCU3z36lZn+LFsk9FXPRelxb/KeABzvPs3r3SrHWy1aA67KGtSFj0xNK2QD0NJQ==",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-vector-icons": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.1.tgz",
@@ -33953,6 +33962,14 @@
       "requires": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      }
+    },
+    "react-native-swiper": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-swiper/-/react-native-swiper-1.6.0.tgz",
+      "integrity": "sha512-OnkTTZi+9uZUgy0uz1I9oYDhCU3z36lZn+LFsk9FXPRelxb/KeABzvPs3r3SrHWy1aA67KGtSFj0xNK2QD0NJQ==",
+      "requires": {
+        "prop-types": "^15.5.10"
       }
     },
     "react-native-vector-icons": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-native-render-html": "^6.3.4",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
+    "react-native-swiper": "^1.6.0",
     "react-native-web": "~0.19.6",
     "react-redux": "^8.1.3",
     "redux": "^4.2.1",

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -1,0 +1,47 @@
+import { decodeText } from "@utils/helper";
+import { imageCarouselStyle } from "@utils/styles";
+import React from "react";
+import { View, Text, ImageBackground } from "react-native";
+import Swiper from "react-native-swiper";
+interface ImageCarouselProps {
+  featuredPosts: {
+    id: number;
+    title: {
+      rendered: string;
+    };
+    jetpack_featured_media_url: string; // Replace with the actual field in your WordPress setup
+    excerpt: {
+      rendered: string;
+    };
+  }[];
+}
+
+const ImageCarousel: React.FC<ImageCarouselProps> = ({ featuredPosts }) => {
+  return (
+    <Swiper
+      style={imageCarouselStyle.wrapper}
+      showsButtons={false}
+      autoplay
+      autoplayTimeout={4}
+      activeDotColor="#fff"
+      key={featuredPosts.length}
+    >
+      {featuredPosts.map((post, index) => (
+        <View key={index}>
+          <ImageBackground
+            source={{ uri: post.jetpack_featured_media_url }}
+            imageStyle={imageCarouselStyle.imageBackground}
+          >
+            <View style={imageCarouselStyle.overlay}>
+              <Text style={imageCarouselStyle.title}>
+                {decodeText(post.title.rendered)}
+              </Text>
+            </View>
+          </ImageBackground>
+        </View>
+      ))}
+    </Swiper>
+  );
+};
+
+export default ImageCarousel;

--- a/src/components/WordPressPost.tsx
+++ b/src/components/WordPressPost.tsx
@@ -10,17 +10,19 @@ const WordPressPost: React.FC<WordPressPostProps> = ({
   excerpt,
 }) => {
   const defaultTextProps = {
-    numberOfLines: 4,
+    numberOfLines: 2,
   };
   return (
     <View style={postStyles.container}>
       <Image source={{ uri: imageUrl }} style={postStyles.image} />
-      <Text style={postStyles.title}>{title}</Text>
-      <HTMLRenderer
-        tagsStyles={htmlTagStyles.tagStyles}
-        htmlContent={excerpt}
-        defaultTextProps={defaultTextProps}
-      />
+      <View style={postStyles.subContainer}>
+        <Text style={postStyles.title}>{title}</Text>
+        <HTMLRenderer
+          tagsStyles={htmlTagStyles.tagStyles}
+          htmlContent={excerpt}
+          defaultTextProps={defaultTextProps}
+        />
+      </View>
     </View>
   );
 };

--- a/src/screens/ExplorePage.tsx
+++ b/src/screens/ExplorePage.tsx
@@ -1,19 +1,25 @@
+import ImageCarousel from "@components/ImageCarousel";
 import WordPressPost from "@components/WordPressPost";
 import { usePosts } from "@storage/hooks/usePosts"; // Adjust the import path based on your project structure
 import { decodeText } from "@utils/helper";
+import { globalStyles, imageCarouselStyle } from "@utils/styles";
 import React, { useEffect } from "react";
 import { View, ScrollView, RefreshControl } from "react-native";
 
 const ExplorePage: React.FC = () => {
   const { posts, loading, error, refetchPosts } = usePosts();
-
+  console.log(posts);
   useEffect(() => {
     // Do something with posts, loading, error
   }, [posts, loading, error]);
 
   return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <View style={imageCarouselStyle.wrapper}>
+        <ImageCarousel featuredPosts={posts} />
+      </View>
       <ScrollView
+        style={globalStyles.scrollViewContainer}
         refreshControl={
           <RefreshControl refreshing={loading} onRefresh={refetchPosts} />
         }

--- a/src/services/storage/actions/posts.ts
+++ b/src/services/storage/actions/posts.ts
@@ -33,7 +33,9 @@ export const fetchPosts =
     dispatch({ type: FETCH_POSTS_REQUEST });
 
     try {
-      const posts = await api.get("posts");
+      const posts = await api.get(
+        "posts?_fields=author,id,excerpt,title,jetpack_featured_media_url",
+      );
       dispatch({ type: FETCH_POSTS_SUCCESS, payload: posts });
     } catch (error: any) {
       dispatch({ type: FETCH_POSTS_FAILURE, payload: error.message });

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -28,23 +28,27 @@ export const globalStyles = StyleSheet.create({
 
 export const postStyles = StyleSheet.create({
   container: {
-    marginBottom: 20,
-    marginHorizontal: 10,
-    padding: 10,
+    flexDirection: "row",
+    marginBottom: 10,
+    marginHorizontal: 5,
     borderWidth: 1,
     borderColor: "#ddd",
+    backgroundColor: "#ddd",
     borderRadius: 8,
+    padding: 10,
+  },
+  subContainer: {
+    width: "70%",
+    paddingHorizontal: 10,
   },
   image: {
-    width: "100%",
-    height: 200,
-    borderRadius: 8,
-    marginBottom: 10,
+    width: "30%",
+    height: 100,
+    alignSelf: "center",
   },
   title: {
-    fontSize: 18,
+    fontSize: 15,
     fontWeight: "bold",
-    marginBottom: 5,
   },
   excerpt: {
     fontSize: 16,

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -15,6 +15,9 @@ export const globalStyles = StyleSheet.create({
     padding: 20,
     backgroundColor: "#fff",
   },
+  scrollViewContainer: {
+    marginTop: 20,
+  },
   titleText: {
     fontSize: 24,
     fontWeight: "bold",
@@ -52,6 +55,30 @@ export const postStyles = StyleSheet.create({
   },
   excerpt: {
     fontSize: 16,
+  },
+});
+
+export const imageCarouselStyle = StyleSheet.create({
+  wrapper: {
+    height: 200,
+  },
+  imageBackground: {
+    flex: 1,
+    height: 200,
+    justifyContent: "center",
+  },
+  overlay: {
+    backgroundColor: "rgba(0, 0, 0, 0.5)", // Adjust the alpha value for the darkness
+    justifyContent: "center",
+    alignItems: "center",
+    height: 200,
+  },
+  title: {
+    color: "#fff",
+    fontSize: 20,
+    fontWeight: "bold",
+    textAlign: "center",
+    margin: 20,
   },
 });
 


### PR DESCRIPTION
**Summary:**
This pull request addresses the issue [#12](https://github.com/yakupafsin/WordpressMobileApp/issues/12): "Add Image Carousel to Explore Page for Popular Posts."

**Changes Proposed:**
- Added an image carousel to the top of the Explore page.
- Implemented dynamic fetching of popular posts from the backend API.
- Integrated react-native-swiper for the carousel functionality.

**Testing:**

1. Open the app
2. Swipe the image carousel left and right.
3. Observe image carousel if changin the images

**Screenshots:**

https://github.com/yakupafsin/WordpressMobileApp/assets/66640310/fb09764e-de51-4337-a449-32ed4f36c882


**Related Issues:**
- Closes #12 

**Checklist:**
- [x] All tests pass.
- [x] Code follows project coding standards.
- [x] Documentation has been updated, if necessary.
- [x] Feature has been tested on different devices and browsers.
